### PR TITLE
Resize pool and maintain ripple interaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,12 +50,14 @@ loadFile('shaders/utils.glsl').then((utils) => {
   // Ray caster
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
-  const targetgeometry = new THREE.PlaneGeometry(4, 4);
+  const targetgeometry = new THREE.PlaneGeometry(2, 2);
   for (let vertex of targetgeometry.vertices) {
     vertex.z = - vertex.y;
     vertex.y = 0.;
   }
   const targetmesh = new THREE.Mesh(targetgeometry);
+  targetmesh.scale.set(2, 1, 2);
+  targetmesh.updateMatrixWorld();
 
   // Textures
   const cubetextureloader = new THREE.CubeTextureLoader();
@@ -163,7 +165,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
   class Water {
 
     constructor() {
-      this.geometry = new THREE.PlaneBufferGeometry(4, 4, 200, 200);
+      this.geometry = new THREE.PlaneBufferGeometry(2, 2, 200, 200);
 
       const shadersPromises = [
         loadFile('shaders/water/vertex.glsl'),
@@ -186,6 +188,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
         });
 
         this.mesh = new THREE.Mesh(this.geometry, this.material);
+        this.mesh.scale.set(2, 1, 2);
       });
     }
 
@@ -208,30 +211,30 @@ loadFile('shaders/utils.glsl').then((utils) => {
     constructor() {
       this._geometry = new THREE.BufferGeometry();
       const vertices = new Float32Array([
-        -2, -1, -2,
-        -2, -1,  2,
-        -2,  1, -2,
-        -2,  1,  2,
-         2, -1, -2,
-         2,  1, -2,
-         2, -1,  2,
-         2,  1,  2,
-        -2, -1, -2,
-         2, -1, -2,
-        -2, -1,  2,
-         2, -1,  2,
-        -2,  1, -2,
-        -2,  1,  2,
-         2,  1, -2,
-         2,  1,  2,
-        -2, -1, -2,
-        -2,  1, -2,
-         2, -1, -2,
-         2,  1, -2,
-        -2, -1,  2,
-         2, -1,  2,
-        -2,  1,  2,
-         2,  1,  2
+        -1, -1, -1,
+        -1, -1, 1,
+        -1, 1, -1,
+        -1, 1, 1,
+        1, -1, -1,
+        1, 1, -1,
+        1, -1, 1,
+        1, 1, 1,
+        -1, -1, -1,
+        1, -1, -1,
+        -1, -1, 1,
+        1, -1, 1,
+        -1, 1, -1,
+        -1, 1, 1,
+        1, 1, -1,
+        1, 1, 1,
+        -1, -1, -1,
+        -1, 1, -1,
+        1, -1, -1,
+        1, 1, -1,
+        -1, -1, 1,
+        1, -1, 1,
+        -1, 1, 1,
+        1, 1, 1
       ]);
       const indices = new Uint32Array([
         0, 1, 2,
@@ -269,6 +272,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
         this._material.side = THREE.FrontSide;
 
         this._mesh = new THREE.Mesh(this._geometry, this._material);
+        this._mesh.scale.set(2, 1, 2);
       });
     }
 

--- a/index.js
+++ b/index.js
@@ -50,13 +50,12 @@ loadFile('shaders/utils.glsl').then((utils) => {
   // Ray caster
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
-  const targetgeometry = new THREE.PlaneGeometry(2, 2);
+  const targetgeometry = new THREE.PlaneGeometry(4, 4);
   for (let vertex of targetgeometry.vertices) {
     vertex.z = - vertex.y;
     vertex.y = 0.;
   }
   const targetmesh = new THREE.Mesh(targetgeometry);
-  targetmesh.scale.set(2, 1, 2);
   targetmesh.updateMatrixWorld();
 
   // Textures
@@ -165,7 +164,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
   class Water {
 
     constructor() {
-      this.geometry = new THREE.PlaneBufferGeometry(2, 2, 200, 200);
+      this.geometry = new THREE.PlaneBufferGeometry(4, 4, 400, 400);
 
       const shadersPromises = [
         loadFile('shaders/water/vertex.glsl'),
@@ -188,7 +187,6 @@ loadFile('shaders/utils.glsl').then((utils) => {
         });
 
         this.mesh = new THREE.Mesh(this.geometry, this.material);
-        this.mesh.scale.set(2, 1, 2);
       });
     }
 
@@ -211,30 +209,30 @@ loadFile('shaders/utils.glsl').then((utils) => {
     constructor() {
       this._geometry = new THREE.BufferGeometry();
       const vertices = new Float32Array([
-        -1, -1, -1,
-        -1, -1, 1,
-        -1, 1, -1,
-        -1, 1, 1,
-        1, -1, -1,
-        1, 1, -1,
-        1, -1, 1,
-        1, 1, 1,
-        -1, -1, -1,
-        1, -1, -1,
-        -1, -1, 1,
-        1, -1, 1,
-        -1, 1, -1,
-        -1, 1, 1,
-        1, 1, -1,
-        1, 1, 1,
-        -1, -1, -1,
-        -1, 1, -1,
-        1, -1, -1,
-        1, 1, -1,
-        -1, -1, 1,
-        1, -1, 1,
-        -1, 1, 1,
-        1, 1, 1
+        -2, -1, -2,
+        -2, -1,  2,
+        -2,  1, -2,
+        -2,  1,  2,
+         2, -1, -2,
+         2,  1, -2,
+         2, -1,  2,
+         2,  1,  2,
+        -2, -1, -2,
+         2, -1, -2,
+        -2, -1,  2,
+         2, -1,  2,
+        -2,  1, -2,
+        -2,  1,  2,
+         2,  1, -2,
+         2,  1,  2,
+        -2, -1, -2,
+        -2,  1, -2,
+         2, -1, -2,
+         2,  1, -2,
+        -2, -1,  2,
+         2, -1,  2,
+        -2,  1,  2,
+         2,  1,  2
       ]);
       const indices = new Uint32Array([
         0, 1, 2,
@@ -272,7 +270,6 @@ loadFile('shaders/utils.glsl').then((utils) => {
         this._material.side = THREE.FrontSide;
 
         this._mesh = new THREE.Mesh(this._geometry, this._material);
-        this._mesh.scale.set(2, 1, 2);
       });
     }
 

--- a/index.js
+++ b/index.js
@@ -209,42 +209,14 @@ loadFile('shaders/utils.glsl').then((utils) => {
     constructor() {
       this._geometry = new THREE.BufferGeometry();
       const vertices = new Float32Array([
-        -2, -1, -2,
-        -2, -1,  2,
-        -2,  1, -2,
-        -2,  1,  2,
-         2, -1, -2,
-         2,  1, -2,
-         2, -1,  2,
-         2,  1,  2,
-        -2, -1, -2,
-         2, -1, -2,
-        -2, -1,  2,
-         2, -1,  2,
         -2,  1, -2,
         -2,  1,  2,
          2,  1, -2,
          2,  1,  2,
-        -2, -1, -2,
-        -2,  1, -2,
-         2, -1, -2,
-         2,  1, -2,
-        -2, -1,  2,
-         2, -1,  2,
-        -2,  1,  2,
-         2,  1,  2
       ]);
       const indices = new Uint32Array([
         0, 1, 2,
         2, 1, 3,
-        4, 5, 6,
-        6, 5, 7,
-        12, 13, 14,
-        14, 13, 15,
-        16, 17, 18,
-        18, 17, 19,
-        20, 21, 22,
-        22, 21, 23
       ]);
 
       this._geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
 
   // Create Renderer
   const camera = new THREE.PerspectiveCamera(75, width / height, 0.01, 100);
-  camera.position.set(0.426, 0.677, -2.095);
+  camera.position.set(0.426, 0.677, -3.0);
   camera.rotation.set(2.828, 0.191, 3.108);
 
   const renderer = new THREE.WebGLRenderer({canvas: canvas, antialias: true, alpha: true});
@@ -50,7 +50,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
   // Ray caster
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
-  const targetgeometry = new THREE.PlaneGeometry(2, 2);
+  const targetgeometry = new THREE.PlaneGeometry(4, 4);
   for (let vertex of targetgeometry.vertices) {
     vertex.z = - vertex.y;
     vertex.y = 0.;
@@ -163,7 +163,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
   class Water {
 
     constructor() {
-      this.geometry = new THREE.PlaneBufferGeometry(2, 2, 200, 200);
+      this.geometry = new THREE.PlaneBufferGeometry(4, 4, 200, 200);
 
       const shadersPromises = [
         loadFile('shaders/water/vertex.glsl'),
@@ -208,30 +208,30 @@ loadFile('shaders/utils.glsl').then((utils) => {
     constructor() {
       this._geometry = new THREE.BufferGeometry();
       const vertices = new Float32Array([
-        -1, -1, -1,
-        -1, -1, 1,
-        -1, 1, -1,
-        -1, 1, 1,
-        1, -1, -1,
-        1, 1, -1,
-        1, -1, 1,
-        1, 1, 1,
-        -1, -1, -1,
-        1, -1, -1,
-        -1, -1, 1,
-        1, -1, 1,
-        -1, 1, -1,
-        -1, 1, 1,
-        1, 1, -1,
-        1, 1, 1,
-        -1, -1, -1,
-        -1, 1, -1,
-        1, -1, -1,
-        1, 1, -1,
-        -1, -1, 1,
-        1, -1, 1,
-        -1, 1, 1,
-        1, 1, 1
+        -2, -1, -2,
+        -2, -1,  2,
+        -2,  1, -2,
+        -2,  1,  2,
+         2, -1, -2,
+         2,  1, -2,
+         2, -1,  2,
+         2,  1,  2,
+        -2, -1, -2,
+         2, -1, -2,
+        -2, -1,  2,
+         2, -1,  2,
+        -2,  1, -2,
+        -2,  1,  2,
+         2,  1, -2,
+         2,  1,  2,
+        -2, -1, -2,
+        -2,  1, -2,
+         2, -1, -2,
+         2,  1, -2,
+        -2, -1,  2,
+         2, -1,  2,
+        -2,  1,  2,
+         2,  1,  2
       ]);
       const indices = new Uint32Array([
         0, 1, 2,
@@ -341,7 +341,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
     if (intersects.length > 0) {
       const intersect = intersects[0];
       // Add a drop at the intersect point with your desired radius and strength for the ripple
-      waterSimulation.addDrop(renderer, intersect.point.x, intersect.point.z, 0.1, 0.1);
+      waterSimulation.addDrop(renderer, intersect.point.x / 2, intersect.point.z / 2, 0.1, 0.1);
     }
   }
   canvas.addEventListener('mousedown', onMouseDown );
@@ -376,7 +376,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
     const intersects = raycaster.intersectObject(targetmesh);
 
     for (let intersect of intersects) {
-      waterSimulation.addDrop(renderer, intersect.point.x, intersect.point.z, 0.02, 0.04);
+      waterSimulation.addDrop(renderer, intersect.point.x / 2, intersect.point.z / 2, 0.02, 0.04);
     }
   }
 
@@ -420,7 +420,7 @@ loadFile('shaders/utils.glsl').then((utils) => {
     for (var i = 0; i < 20; i++) {
       waterSimulation.addDrop(
         renderer,
-        Math.random() * 2 - 1, Math.random() * 2 - 1,
+        (Math.random() * 4 - 2) / 2, (Math.random() * 4 - 2) / 2,
         0.03, (i & 1) ? 0.02 : -0.02
       );
     }

--- a/shaders/pool/fragment.glsl
+++ b/shaders/pool/fragment.glsl
@@ -9,7 +9,7 @@ varying vec3 pos;
 void main() {
   gl_FragColor = vec4(getWallColor(pos), 1.0);
 
-  vec4 info = texture2D(water, pos.xz * 0.5 + 0.5);
+  vec4 info = texture2D(water, pos.xz * 0.25 + 0.5);
 
   if (pos.y < info.r) {
     gl_FragColor.rgb *= underwaterColor * 1.2;

--- a/shaders/utils.glsl
+++ b/shaders/utils.glsl
@@ -26,18 +26,8 @@ vec2 intersectCube(vec3 origin, vec3 ray, vec3 cubeMin, vec3 cubeMax) {
 vec3 getWallColor(vec3 point) {
   float scale = 0.5;
 
-  vec3 wallColor;
-  vec3 normal;
-  if (abs(point.x) > 1.999) {
-    wallColor = texture2D(tiles, vec2(point.y * 0.5, point.z * 0.25) + vec2(1.0, 0.5)).rgb;
-    normal = vec3(-point.x, 0.0, 0.0);
-  } else if (abs(point.z) > 1.999) {
-    wallColor = texture2D(tiles, vec2(point.y * 0.5, point.x * 0.25) + vec2(1.0, 0.5)).rgb;
-    normal = vec3(0.0, 0.0, -point.z);
-  } else {
-    wallColor = texture2D(tiles, point.xz * 0.25 + 0.5).rgb;
-    normal = vec3(0.0, 1.0, 0.0);
-  }
+  vec3 wallColor = texture2D(tiles, point.xz * 0.25 + 0.5).rgb;
+  vec3 normal = vec3(0.0, 1.0, 0.0);
 
   scale /= length(point); /* pool ambient occlusion */
 

--- a/shaders/utils.glsl
+++ b/shaders/utils.glsl
@@ -28,14 +28,14 @@ vec3 getWallColor(vec3 point) {
 
   vec3 wallColor;
   vec3 normal;
-  if (abs(point.x) > 0.999) {
-    wallColor = texture2D(tiles, point.yz * 0.5 + vec2(1.0, 0.5)).rgb;
+  if (abs(point.x) > 1.999) {
+    wallColor = texture2D(tiles, vec2(point.y * 0.5, point.z * 0.25) + vec2(1.0, 0.5)).rgb;
     normal = vec3(-point.x, 0.0, 0.0);
-  } else if (abs(point.z) > 0.999) {
-    wallColor = texture2D(tiles, point.yx * 0.5 + vec2(1.0, 0.5)).rgb;
+  } else if (abs(point.z) > 1.999) {
+    wallColor = texture2D(tiles, vec2(point.y * 0.5, point.x * 0.25) + vec2(1.0, 0.5)).rgb;
     normal = vec3(0.0, 0.0, -point.z);
   } else {
-    wallColor = texture2D(tiles, point.xz * 0.5 + 0.5).rgb;
+    wallColor = texture2D(tiles, point.xz * 0.25 + 0.5).rgb;
     normal = vec3(0.0, 1.0, 0.0);
   }
 
@@ -44,13 +44,13 @@ vec3 getWallColor(vec3 point) {
   /* caustics */
   vec3 refractedLight = -refract(-light, vec3(0.0, 1.0, 0.0), IOR_AIR / IOR_WATER);
   float diffuse = max(0.0, dot(refractedLight, normal));
-  vec4 info = texture2D(water, point.xz * 0.5 + 0.5);
+  vec4 info = texture2D(water, point.xz * 0.25 + 0.5);
   if (point.y < info.r) {
     vec4 caustic = texture2D(causticTex, 0.75 * (point.xz - point.y * refractedLight.xz / refractedLight.y) * 0.5 + 0.5);
     scale += diffuse * caustic.r * 2.0 * caustic.g;
   } else {
     /* shadow for the rim of the pool */
-    vec2 t = intersectCube(point, refractedLight, vec3(-1.0, -poolHeight, -1.0), vec3(1.0, 2.0, 1.0));
+    vec2 t = intersectCube(point, refractedLight, vec3(-2.0, -poolHeight, -2.0), vec3(2.0, 2.0, 2.0));
     diffuse *= 1.0 / (1.0 + exp(-200.0 / (1.0 + 10.0 * (t.y - t.x)) * (point.y + refractedLight.y * t.y - 2.0 / 12.0)));
 
     scale += diffuse * 0.5;

--- a/shaders/water/vertex.glsl
+++ b/shaders/water/vertex.glsl
@@ -9,7 +9,7 @@ varying vec3 pos;
 
 
 void main() {
-  vec4 info = texture2D(water, position.xy * 0.5 + 0.5);
+  vec4 info = texture2D(water, position.xy * 0.25 + 0.5);
   pos = position.xzy;
   pos.y += info.r;
 


### PR DESCRIPTION
## Summary
- expand plane and pool geometry to 4x4
- reposition the camera for the larger pool
- scale mouse interaction coordinates
- randomly seed ripples across the wider surface

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889a0c02de0832a86910ffefd6eaafb